### PR TITLE
NEW Adds endpoint to query for cards metadata containing tags list

### DIFF
--- a/app/v1/card/CardController.scala
+++ b/app/v1/card/CardController.scala
@@ -140,6 +140,17 @@ class CardController @Inject()(
   }
 
   /**
+    * Returns the metadata for the cards.
+    */
+  def getMetadata() = silhouette.SecuredAction.async { implicit request =>
+    logger.info(s"Getting metadata for cards...")
+
+    def serialize(m: CardMetadataResource) = Ok(Json.toJson(m))
+
+    resourceHandler.getMetadata(request.identity).map(serialize _).recover(handleError _)
+  }
+
+  /**
     * Handles errors.
     */
   private def handleError(error: Throwable): Result = error match {

--- a/app/v1/card/CardRepository.scala
+++ b/app/v1/card/CardRepository.scala
@@ -49,6 +49,7 @@ trait CardRepository {
   def get(id: String, user: User): Option[CardData]
   def find(r: CardListRequest): Iterable[CardData]
   def countItemsMatching(req: CardListRequest): Int
+  def getAllTags(user: User): Future[List[String]]
 }
 
 
@@ -141,6 +142,19 @@ class CardRepositoryImpl @Inject()(
     tagsRepo.delete(data.id.get)
     tagsRepo.create(data.id.get, data.tags)
   }}}
+
+  /**
+    * Returns all tags for a given user.
+    */
+  def getAllTags(user: User): Future[List[String]] = Future { db.withTransaction { implicit c =>
+    import anorm.SqlParser._
+    SQL"""
+       SELECT tag
+       FROM cardsTags
+       JOIN cards ON cards.id = cardId
+       WHERE cards.userId = ${user.id}
+    """.as(str(1).*)
+  }}
 }
 
 /**

--- a/app/v1/card/CardResourceHandler.scala
+++ b/app/v1/card/CardResourceHandler.scala
@@ -44,6 +44,16 @@ object CardResource {
 
 }
 
+/**
+  * Data transfer object for card metadata.
+  */
+case class CardMetadataResource(tags: List[String]) //!!!! TODO
+
+object CardMetadataResource {
+
+  implicit val format: Format[CardMetadataResource] = Json.format
+
+}
 
 /**
   * Represents a request for a list of CardResource.
@@ -120,5 +130,9 @@ class CardResourceHandler @Inject()(
       }
       case None => Future(Failure(new CardDoesNotExist))
     }
+  }
+
+  def getMetadata(user: User): Future[CardMetadataResource] = {
+    repository.getAllTags(user).map(CardMetadataResource(_))
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,7 @@ GET     /assets/*file               controllers.Assets.versioned(path="/public",
 
 # CRUD For a card
 ->      /v1/cards                   v1.card.CardRouter
+GET     /v1/metadata/cards          v1.card.CardController.getMetadata
 
 # Cards Grid Profiles
 ->     /v1/cards-grid-profile       v1.cardGridProfile.CardGridProfileRouter

--- a/test/v1/card/CardControllerSpec.scala
+++ b/test/v1/card/CardControllerSpec.scala
@@ -54,14 +54,15 @@ class CardControllerSpec
 
   after { TestUtils.cleanupDb(db) }
 
-  "list" should {
 
-    def createCard(): Unit = {
-      val body = Json.obj("title" -> "Title", "body" -> "Body", "tags" -> List("Tag1", "Tag2"))
-      val request = FakeRequest().withJsonBody(body)
-      val response = controller.create()(request)
-      Await.ready(response, 1000 millis)
-    }
+  def createCard(): Unit = {
+    val body = Json.obj("title" -> "Title", "body" -> "Body", "tags" -> List("Tag1", "Tag2"))
+    val request = FakeRequest().withJsonBody(body)
+    val response = controller.create()(request)
+    Await.ready(response, 1000 millis)
+  }
+
+  "list" should {
 
     def runQuery(tagsQuery: String): Future[Result] = {
       val body = Json.obj("page" -> "1", "pageSize" -> "2", "query" -> tagsQuery)
@@ -105,6 +106,28 @@ class CardControllerSpec
       status(response) mustEqual 400
       val responseMsg = (contentAsJson(response) \ "message").as[String]
       responseMsg.contains("FOO")
+    }
+
+  }
+
+  "getMetadata" should {
+
+    def runGetMetadata() = {
+      val request = FakeRequest()
+      controller.getMetadata()(request)
+    }
+
+    "returns the metadata for cards" in {
+
+      //Creates a card with a couple of tags
+      createCard()
+
+      //Runs the request
+      val response = runGetMetadata()
+
+      //Expects the two tags to be on the response
+      status(response) mustEqual 200
+      contentAsJson(response) mustEqual Json.obj("tags" -> Seq("Tag1", "Tag2"))
     }
 
   }

--- a/test/v1/card/CardResourceHandlerSpec.scala
+++ b/test/v1/card/CardResourceHandlerSpec.scala
@@ -178,4 +178,20 @@ class CardResourceHandlerSpec
 
   }
 
+  "CardResourceHandler.getMetadata" should {
+
+    "get the tags from the repository and transforms to a resource" in {
+      val tags = List("FOO", "BAR")
+      val user = mock[User]
+
+      val repository = mock[CardRepositoryImpl]
+      when(repository.getAllTags(user)).thenReturn(Future.successful(tags))
+
+      val exp = CardMetadataResource(tags)
+      val res = new CardResourceHandler(repository).getMetadata(user).futureValue
+      exp mustEqual res
+    }
+
+  }
+
 }


### PR DESCRIPTION
Adds a new endpoint /v1/metadata/cards to retrieve metadata for cards,
which currently includes a list of all tags for an user.